### PR TITLE
Add Named Routes

### DIFF
--- a/jam_scene_UI/lib/components/authentication_wrapper.dart
+++ b/jam_scene_UI/lib/components/authentication_wrapper.dart
@@ -3,14 +3,16 @@ import 'package:flutter/material.dart';
 import '../screens/profile_page.dart';
 import '../screens/login_page.dart';
 
-class AuthticationWrapper extends StatefulWidget {
-  const AuthticationWrapper({Key? key}) : super(key: key);
+class AuthenticationWrapper extends StatefulWidget {
+  const AuthenticationWrapper({Key? key}) : super(key: key);
+
+  static const routeName = '/';
 
   @override
-  State<AuthticationWrapper> createState() => _AuthticationWrapperState();
+  State<AuthenticationWrapper> createState() => _AuthticationWrapperState();
 }
 
-class _AuthticationWrapperState extends State<AuthticationWrapper> {
+class _AuthticationWrapperState extends State<AuthenticationWrapper> {
   var currentUser = FirebaseAuth.instance.currentUser;
 
   @override

--- a/jam_scene_UI/lib/main.dart
+++ b/jam_scene_UI/lib/main.dart
@@ -9,19 +9,25 @@ void main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
 
-  runApp(const App());
+  runApp(App());
 }
 
 class App extends StatelessWidget {
-  const App({Key? key}) : super(key: key);
+  App({Key? key}) : super(key: key);
+
+  final routes = {
+    AuthenticationWrapper.routeName: (context) => const AuthenticationWrapper(),
+  };
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-        title: 'JamScene',
-        theme: ThemeData(
-          primarySwatch: Colors.blue,
-        ),
-        home: const AuthticationWrapper());
+      initialRoute: AuthenticationWrapper.routeName,
+      title: 'JamScene',
+      routes: routes,
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+    );
   }
 }

--- a/jam_scene_UI/lib/screens/login_page.dart
+++ b/jam_scene_UI/lib/screens/login_page.dart
@@ -7,7 +7,9 @@ import '../components/background_texture.dart';
 import '../models/google_sign_in_functions.dart';
 
 /*
-  Login and registration forms are contained in this widget.
+  Login and registration forms are contained in this widget. Note that this
+  widget does not have its own route. App uses AuthticationWrapper to route to
+  login/registration.
   
   Reference: 
   This widget was derived from the Google Firebase Auth quickstart


### PR DESCRIPTION
- App -> MaterialApp now uses named routes in place of a home screen. 
- Initial route is set to AuthenticationWrapper, which will display either the Login or Register page.
![image](https://user-images.githubusercontent.com/11380185/178346304-c00d807f-c402-478a-900b-2dcec2841d60.png)

- New routes moving forward should be added to the routes collection in the MaterialApp as well as defined as a static variable in their widget like this:
![image](https://user-images.githubusercontent.com/11380185/178346626-61fbe867-f8ec-471e-9760-e36f1730d391.png)
