### PR TITLE
Add signout button to settings page.

### DIFF
--- a/jam_scene_UI/lib/screens/settings_page.dart
+++ b/jam_scene_UI/lib/screens/settings_page.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
 class SettingsPage extends StatefulWidget {
@@ -8,10 +9,14 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
+  void _logOut() {
+    FirebaseAuth.instance.signOut();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text("Settings Page"),
+    return Center(
+      child: ElevatedButton(onPressed: _logOut, child: const Text("Log Out")),
     );
   }
 }


### PR DESCRIPTION
-Add sign out button to settings page which signs user out of their google sign in. 
-Auth wrapper detects that user token has changed and sets the app user to null, returning them to the log-in screen.