### PR TITLE
Layout update profile

### DIFF
--- a/jam_scene_UI/lib/screens/profile_page.dart
+++ b/jam_scene_UI/lib/screens/profile_page.dart
@@ -92,7 +92,10 @@ class _ProfilePageState extends State<ProfilePage> {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Flexible(child: Text(profileData.description)),
+                          Flexible(
+                              child: Text(profileData.description,
+                                  overflow: TextOverflow.ellipsis,
+                                  maxLines: 4)),
                         ],
                       ),
                       Row(
@@ -107,28 +110,37 @@ class _ProfilePageState extends State<ProfilePage> {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.start,
                         children: [
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              const Text("Influences",
-                                  style:
-                                      TextStyle(fontWeight: FontWeight.bold)),
-                              Text(profileData.influences),
-                            ],
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                const Text(
+                                  "Influences",
+                                  style: TextStyle(fontWeight: FontWeight.bold),
+                                ),
+                                Text(
+                                  profileData.influences,
+                                  maxLines: 4,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ],
+                            ),
                           ),
                         ],
                       ),
                       Row(
                         mainAxisAlignment: MainAxisAlignment.start,
                         children: [
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              const Text("Recordings",
-                                  style:
-                                      TextStyle(fontWeight: FontWeight.bold)),
-                              Text(profileData.recordings),
-                            ],
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                const Text("Recordings",
+                                    style:
+                                        TextStyle(fontWeight: FontWeight.bold)),
+                                Text(profileData.recordings),
+                              ],
+                            ),
                           ),
                         ],
                       ),


### PR DESCRIPTION
Fixed layout bug which caused a render over flow in the profile page when a user added a long string with no spaces, such as a url link to their influences or recordings.

![image](https://user-images.githubusercontent.com/11380185/180052124-bda6e386-ceaa-4b58-bee8-0af91b91ef99.png)
