### PR TITLE
Opp other peoples profiles

### DIFF
--- a/jam_scene_UI/lib/screens/profile_page.dart
+++ b/jam_scene_UI/lib/screens/profile_page.dart
@@ -268,6 +268,7 @@ class _ProfilePageState extends State<ProfilePage> {
                           ),
                         ],
                       ),
+                      const SizedBox(height: 1000),
                     ],
                   ),
                 ),


### PR DESCRIPTION
**Adds the ability to view other users' profiles by clicking on them in the search results.**
- ProfilePage widget now has argument for other user's id so the widget can be used for viewing the main profile and for viewing other user profiles.
- ProfilePage widget now can make api calls for profile data based whether or not another user's id was passed to it.
- Added viewing other profile state to search results view.
- Minor changes to search page behavior to facilitate navigation between search form, search results, and selected user profiles.