### PR TITLE
Ad chat refresh on scroll bottom. Add respond to ads.

### DIFF
--- a/jam_scene_UI/TestQueries/chat.http
+++ b/jam_scene_UI/TestQueries/chat.http
@@ -12,7 +12,7 @@ content-type: application/json
     "convoId": "1bdbaeae-0c1a-42cb-9cba-e737a76f9b36+MqEuBlsfIug8Ozfjl2o8IkIyPr43",
     "senderId": "1bdbaeae-0c1a-42cb-9cba-e737a76f9b36",
     "receiverId": "MqEuBlsfIug8Ozfjl2o8IkIyPr43",
-    "body": "French horn!",
+    "body": "I know!",
     "time_sent": "2022-8-01 13:41:00"
   }
 

--- a/jam_scene_UI/lib/screens/ad_respond_page.dart
+++ b/jam_scene_UI/lib/screens/ad_respond_page.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:firebase_auth/firebase_auth.dart';
 
 class AdRespond extends StatefulWidget {
   const AdRespond(
@@ -12,6 +15,38 @@ class AdRespond extends StatefulWidget {
 }
 
 class _AdRespondState extends State<AdRespond> {
+  final GlobalKey adRespondFormKey = GlobalKey<FormState>();
+  final TextEditingController messageController = TextEditingController();
+
+  String getConvoId() {
+    String uid = FirebaseAuth.instance.currentUser!.uid;
+    List<String> users = [uid, widget.adDetails['posted_by']];
+    users.sort();
+    return "${users[0]}+${users[1]}";
+  }
+
+  void sendMessage(BuildContext context) async {
+    if (messageController.text.isEmpty) {
+      return;
+    }
+    var message = {
+      'convoId': getConvoId(),
+      'senderId': FirebaseAuth.instance.currentUser!.uid,
+      'receiverId': widget.adDetails['posted_by'],
+      'body': messageController.text,
+      'time_sent': DateTime.now().toString(),
+    };
+
+    var url = Uri.parse('https://jam-scene-app.herokuapp.com/messages/');
+    var response = await http.post(url,
+        headers: {'content-type': 'application/json'},
+        body: json.encode(message));
+    if (response.statusCode == 200) {
+      messageController.clear();
+      widget.adsPageStateUpdater({'_currView': 'AdDetails'});
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Center(
@@ -32,6 +67,36 @@ class _AdRespondState extends State<AdRespond> {
             ],
           ),
           Text('Responding to user ${widget.adDetails['username']}'),
+          // response form
+          Form(
+            key: adRespondFormKey,
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: TextFormField(
+                    controller: messageController,
+                    maxLines: null,
+                    minLines: 6,
+                    decoration: const InputDecoration(
+                      labelText: 'Message',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ),
+                // send button
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: ElevatedButton(
+                    child: const Text('Send'),
+                    onPressed: () {
+                      sendMessage(context);
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
         ],
       ),
     );

--- a/jam_scene_UI/lib/screens/chat_conversations_page.dart
+++ b/jam_scene_UI/lib/screens/chat_conversations_page.dart
@@ -25,7 +25,9 @@ class ConversationsPage extends StatelessWidget {
             ? const Text("No conversations")
             : Expanded(
                 child: RefreshIndicator(
-                  onRefresh: () async {},
+                  onRefresh: () async {
+                    messageUpdater();
+                  },
                   child: ListView.separated(
                     separatorBuilder: (context, index) => const Divider(),
                     itemCount: conversations.length,

--- a/jam_scene_UI/lib/screens/chat_messages_page.dart
+++ b/jam_scene_UI/lib/screens/chat_messages_page.dart
@@ -37,7 +37,6 @@ class _ChatMessagesPageState extends State<ChatMessagesPage> {
         await http.get(url, headers: {'content-type': 'application/json'});
     if (response.statusCode == 200) {
       var data = json.decode(response.body);
-      debugPrint(data.toString());
       setState(() {
         messages = data;
         loadingMessages = false;
@@ -107,18 +106,26 @@ class _ChatMessagesPageState extends State<ChatMessagesPage> {
                 flex: 9, child: Center(child: CircularProgressIndicator()))
             : Expanded(
                 flex: 9,
-                child: RefreshIndicator(
-                  triggerMode: RefreshIndicatorTriggerMode.onEdge,
-                  onRefresh: () async {
-                    _updateMessages();
+                child: NotificationListener(
+                  onNotification: (ScrollNotification notification) {
+                    if (notification is ScrollEndNotification) {
+                      _updateMessages();
+                    }
+                    return true;
                   },
-                  child: ListView.builder(
-                      itemCount: messages.length,
-                      itemBuilder: (context, index) {
-                        return messages[index]["senderid"] == uid
-                            ? SenderChatMessage(message: messages[index])
-                            : ReceiverChatMessage(message: messages[index]);
-                      }),
+                  child: RefreshIndicator(
+                    triggerMode: RefreshIndicatorTriggerMode.onEdge,
+                    onRefresh: () async {
+                      _updateMessages();
+                    },
+                    child: ListView.builder(
+                        itemCount: messages.length,
+                        itemBuilder: (context, index) {
+                          return messages[index]["senderid"] == uid
+                              ? SenderChatMessage(message: messages[index])
+                              : ReceiverChatMessage(message: messages[index]);
+                        }),
+                  ),
                 ),
               ),
         Form(


### PR DESCRIPTION
**Adds Chat refresh options and respond to ads feature**

1. User can scroll to bottom of chat messages to update them.
2. The user can now respond to other users' ads.