### PR TITLE
bug fix for fast switching between tabs.

### DIFF
--- a/jam_scene_UI/lib/screens/messages_page.dart
+++ b/jam_scene_UI/lib/screens/messages_page.dart
@@ -26,6 +26,9 @@ class _MessagesPageState extends State<MessagesPage> {
   }
 
   void _getConversations() async {
+    if (!mounted) {
+      return;
+    }
     setState(() {
       currView = "Loading";
     });
@@ -39,6 +42,9 @@ class _MessagesPageState extends State<MessagesPage> {
 
     if (response.statusCode == 200) {
       var data = json.decode(response.body);
+      if (!mounted) {
+        return;
+      }
       setState(() {
         conversations = data;
         currView = "Conversations";
@@ -51,6 +57,9 @@ class _MessagesPageState extends State<MessagesPage> {
   }
 
   void messagesTabStateUpdater(Map<String, dynamic> stateChanges) {
+    if (!mounted) {
+      return;
+    }
     setState(() {
       if (stateChanges.containsKey('_currView')) {
         currView = stateChanges['_currView'];

--- a/jam_scene_UI/lib/screens/profile_page.dart
+++ b/jam_scene_UI/lib/screens/profile_page.dart
@@ -43,12 +43,18 @@ class _ProfilePageState extends State<ProfilePage> {
     var uri = Uri.parse(url);
     var response = await http.get(uri, headers: {'Authorization': token});
     if (jsonDecode(response.body)['user'].isEmpty) {
+      if (!mounted) {
+        return;
+      }
       return setState(() {
         loading = false;
         newUser = true;
       });
     }
 
+    if (!mounted) {
+      return;
+    }
     setState(() {
       profileData = ProfileData.fromJson(jsonDecode(response.body)['user'][0]);
       loading = false;


### PR DESCRIPTION
**Bug fix: Crash when switching tabs too quickly**

- Occasionally when switching tabs quickly, the app would crash due to setState() being called on an unmounted widget. This fix adds a check that the widgets are mounted on each tab prior to calling setState.

